### PR TITLE
Add command to update GitHub token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added a command `gantry config set-gh-token` for setting or updating your GitHub personal access token for a Beaker workspace.
+
 ## [v0.4.0](https://github.com/allenai/beaker-gantry/releases/tag/v0.4.0) - 2022-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ pip install -e .
     find and use the existing configuration file (usually located at `$HOME/.beaker/config.yml`).
     Otherwise just set the environment variable `BEAKER_TOKEN` to your Beaker [user token](https://beaker.org/user).
 
-    The first time you call `gantry run ...` you'll also be prompted to provide a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with the `repo` scope. This allows Gantry to clone your private repository when it runs in Beaker (you don't have to do this just yet, wait until you get prompted).
+    The first time you call `gantry run ...` you'll also be prompted to provide a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with the `repo` scope. This allows Gantry to clone your private repository when it runs in Beaker. You don't have to do this just yet (Gantry will prompt you for it), but if you need to update this token later you can use the `gantry config set-gh-token` command.
 
 3. **Specify your Python environment.**
 
@@ -259,6 +259,10 @@ Yes. When you choose an on-premise cluster managed by the Beaker team that suppo
 
 You can use the `--dry-run` option with `gantry run` to see what Gantry will submit without actually submitting an experiment.
 You can also use `--save-spec PATH` in combination with `--dry-run` to save the actual experiment spec to a YAML file.
+
+### How can I update Gantry's GitHub token?
+
+Just use the command `gantry config set-gh-token`.
 
 ### Why "Gantry"?
 

--- a/gantry/__main__.py
+++ b/gantry/__main__.py
@@ -6,10 +6,9 @@ from typing import Optional, Tuple
 
 import click
 import rich
+from beaker import SecretNotFound, TaskResources
 from click_help_colors import HelpColorsCommand, HelpColorsGroup
 from rich import pretty, print, prompt, traceback
-
-from beaker import SecretNotFound, TaskResources
 
 from .common import constants, util
 from .common.aliases import PathOrStr

--- a/gantry/__main__.py
+++ b/gantry/__main__.py
@@ -285,7 +285,11 @@ def run(
         if not gh_token:
             raise ConfigurationError("token cannot be empty!")
         beaker.secret.write(gh_token_secret, gh_token)
-        print(f"GitHub token secret uploaded to workspace as '{gh_token_secret}'")
+        print(
+            f"GitHub token secret uploaded to workspace as '{gh_token_secret}'.\n"
+            f"If you need to update this secret in the future, use the command:\n"
+            f"[i]$ gantry config set-gh-token[/]"
+        )
 
     gh_token_secret = util.ensure_github_token_secret(beaker, gh_token_secret)
 

--- a/gantry/__main__.py
+++ b/gantry/__main__.py
@@ -6,9 +6,10 @@ from typing import Optional, Tuple
 
 import click
 import rich
-from beaker import Beaker, SecretNotFound, TaskResources, WorkspaceNotSet
 from click_help_colors import HelpColorsCommand, HelpColorsGroup
 from rich import pretty, print, prompt, traceback
+
+from beaker import SecretNotFound, TaskResources
 
 from .common import constants, util
 from .common.aliases import PathOrStr
@@ -242,7 +243,7 @@ def run(
     """
     Run an experiment on Beaker.
 
-    E.g.
+    Example:
 
     $ gantry run --name 'hello-world' -- python -c 'print("Hello, World!")'
     """
@@ -261,30 +262,7 @@ def run(
     )
 
     # Initialize Beaker client and validate workspace.
-    beaker = (
-        Beaker.from_env() if workspace is None else Beaker.from_env(default_workspace=workspace)
-    )
-    try:
-        permissions = beaker.workspace.get_permissions()
-        if len(permissions.authorizations) > 1:
-            print_stderr(
-                f"[yellow]Your workspace [b]{beaker.workspace.url()}[/] multiple contributors! "
-                f"Every contributor can view your GitHub personal access token secret ('{gh_token_secret}').[/]"
-            )
-            if not yes and not prompt.Confirm.ask(
-                "[yellow][i]Are you sure you want to use this workspace?[/][/]"
-            ):
-                raise KeyboardInterrupt
-        elif workspace is None:
-            default_workspace = beaker.workspace.get()
-            if not yes and not prompt.Confirm.ask(
-                f"Using default workspace [b cyan]{default_workspace.full_name}[/]. [i]Is that correct?[/]"
-            ):
-                raise KeyboardInterrupt
-    except WorkspaceNotSet:
-        raise ConfigurationError(
-            "'--workspace' option is required since you don't have a default workspace set"
-        )
+    beaker = util.ensure_workspace(workspace=workspace, yes=yes, gh_token_secret=gh_token_secret)
 
     # Get repository account, name, and current ref.
     github_account, github_repo, git_ref = util.ensure_repo(allow_dirty)
@@ -412,6 +390,64 @@ def run(
     metrics = beaker.experiment.metrics(experiment)
     if metrics is not None:
         print("[b]Metrics:[/]", metrics)
+
+
+@main.group(**_CLICK_GROUP_DEFAULTS)
+def config():
+    """
+    Configure Gantry for a specific Beaker workspace.
+    """
+
+
+@config.command(**_CLICK_COMMAND_DEFAULTS)
+@click.argument("token")
+@click.option(
+    "-w",
+    "--workspace",
+    type=str,
+    help="""The Beaker workspace to use.
+    If not specified, your default workspace will be used.""",
+)
+@click.option(
+    "-s",
+    "--secret",
+    type=str,
+    help="""The name of the Beaker secret to write to.""",
+    default=constants.GITHUB_TOKEN_SECRET,
+    show_default=True,
+)
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    help="""Skip all confirmation prompts.""",
+)
+def set_gh_token(
+    token: str,
+    workspace: Optional[str] = None,
+    secret: str = constants.GITHUB_TOKEN_SECRET,
+    yes: bool = False,
+):
+    """
+    Set or update Gantry's GitHub token for the workspace.
+
+    You can create a suitable GitHub token by going to https://github.com/settings/tokens/new
+    and generating a token with the '\N{ballot box with check} repo' scope.
+
+    Example:
+
+    $ gantry config set-gh-token "$GITHUB_TOKEN"
+    """
+    # Initialize Beaker client and validate workspace.
+    beaker = util.ensure_workspace(workspace=workspace, yes=yes, gh_token_secret=secret)
+
+    # Write token to secret.
+    beaker.secret.write(secret, token)
+
+    print(
+        f"[green]\N{check mark} GitHub token added to workspace "
+        f"'{beaker.config.default_workspace}' as the secret '{secret}'"
+    )
 
 
 if __name__ == "__main__":

--- a/gantry/common/util.py
+++ b/gantry/common/util.py
@@ -5,9 +5,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple
 
 import rich
-from rich import print, prompt
-from rich.console import Console
-
 from beaker import (
     Beaker,
     Dataset,
@@ -18,8 +15,10 @@ from beaker import (
     SecretNotFound,
     TaskResources,
     TaskSpec,
-    WorkspaceNotSet
+    WorkspaceNotSet,
 )
+from rich import print, prompt
+from rich.console import Console
 
 from ..exceptions import *
 from ..version import VERSION

--- a/gantry/common/util.py
+++ b/gantry/common/util.py
@@ -322,7 +322,7 @@ def ensure_workspace(
         permissions = beaker.workspace.get_permissions()
         if len(permissions.authorizations) > 1:
             print_stderr(
-                f"[yellow]Your workspace [b]{beaker.workspace.url()}[/] multiple contributors! "
+                f"[yellow]Your workspace [b]{beaker.workspace.url()}[/] has multiple contributors! "
                 f"Every contributor can view your GitHub personal access token secret ('{gh_token_secret}').[/]"
             )
             if not yes and not prompt.Confirm.ask(


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Closes #11 

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Adds a command `gantry config set-gh-token` to set or update Gantry's GitHub PAT for a given Beaker workspace.