### PR TITLE
Add `--dataset` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `--dataset` option for attaching input datasets to an experiment.
+  For example: `gantry run --dataset 'petew/squad-train:/input-data' -- ls /input-data`
+
 ## [v0.5.2](https://github.com/allenai/beaker-gantry/releases/tag/v0.5.2) - 2022-06-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -264,6 +264,14 @@ You can also use `--save-spec PATH` in combination with `--dry-run` to save the 
 
 Just use the command `gantry config set-gh-token`.
 
+### How can I attach Beaker datasets to an experiment?
+
+Just use the `--dataset` option for `gantry run`. For example:
+
+```bash
+gantry run --dataset 'petew/squad-train:/input-data' -- ls /input-data
+```
+
 ### Why "Gantry"?
 
 A gantry is a structure that's used, among other things, to lift containers off of ships. Analogously Beaker Gantry's purpose is to lift Docker containers (or at least the *management* of Docker containers) away from users.


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Closes #13 

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Adds a `--dataset` option for mounting an input dataset. For example:

```bash
gantry run --dataset 'petew/squad-train:/input-data' -- ls /input-data
```

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/beaker-gantry/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/beaker-gantry/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
