### PR TITLE
fix: memory and shared-memory type

### DIFF
--- a/gantry/__main__.py
+++ b/gantry/__main__.py
@@ -144,12 +144,12 @@ def main():
 )
 @click.option(
     "--memory",
-    type=int,
+    type=str,
     help="""Minimum available system memory as a number with unit suffix (e.g. 2.5GiB).""",
 )
 @click.option(
     "--shared-memory",
-    type=int,
+    type=str,
     help="""Size of /dev/shm as a number with unit suffix (e.g. 2.5GiB).""",
 )
 @click.option(


### PR DESCRIPTION
`gantry run --shared-memory 32GiB --memory 100GiB` would fail

memory and shared-memory type should be `str` instead of `int` according to doc: https://beaker-docs.apps.allenai.org/concept/experiments.html#taskresources