### PR TITLE
Add '--priority' option, allow submitting to multiple clusters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,11 +68,9 @@ jobs:
               name: Example - Hello, World!
               run: |
                 run_name=$(python conftest.py run_name)
-                cluster=$(python conftest.py cluster)
                 gantry run \
                   --workspace "$BEAKER_WORKSPACE" \
                   --name "$run_name" \
-                  --cluster "$cluster" \
                   --timeout -1 \
                   --yes \
                   -- python -c 'print("Hello, World!")'
@@ -82,11 +80,9 @@ jobs:
               name: Example - Metrics 
               run: |
                 run_name=$(python conftest.py run_name)
-                cluster=$(python conftest.py cluster)
                 gantry run \
                   --workspace "$BEAKER_WORKSPACE" \
                   --name "$run_name" \
-                  --cluster "$cluster" \
                   --timeout -1 \
                   --yes \
                   -- python examples/metrics/run.py
@@ -96,11 +92,9 @@ jobs:
               name: Example - Conda
               run: |
                 run_name=$(python conftest.py run_name)
-                cluster=$(python conftest.py cluster)
                 gantry run \
                   --workspace "$BEAKER_WORKSPACE" \
                   --name "$run_name" \
-                  --cluster "$cluster" \
                   --timeout -1 \
                   --conda test_fixtures/conda/environment.yml \
                   --yes \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- You can now set the priority of your jobs via `--priority`.
+- By default if you don't specify a cluster and priority, jobs will be submitted to all clusters under preemptible priority.
+
 ## [v0.8.2](https://github.com/allenai/beaker-gantry/releases/tag/v0.8.2) - 2023-01-19
 
 ### Added

--- a/gantry/__main__.py
+++ b/gantry/__main__.py
@@ -387,7 +387,6 @@ def run(
         rich.get_console().rule("[b]Dry run[/]")
         print(
             f"[b]Workspace:[/] {beaker.workspace.url()}\n"
-            f"[b]Cluster:[/] {beaker.cluster.url(cluster_to_use)}\n"
             f"[b]Commit:[/] https://github.com/{github_account}/{github_repo}/commit/{git_ref}\n"
             f"[b]Experiment spec:[/]",
             spec.to_json(),
@@ -418,7 +417,7 @@ def run(
             while job is None:
                 time.sleep(1.0)
                 print(".", end="")
-                job = beaker.experiment.tasks(experiment.id)[0].latest_job
+                job = beaker.experiment.tasks(experiment.id)[0].latest_job  # type: ignore
 
             # Stream the logs.
             print()
@@ -426,7 +425,7 @@ def run(
 
             last_timestamp: Optional[str] = None
             while exit_code is None:
-                job = beaker.experiment.tasks(experiment.id)[0].latest_job
+                job = beaker.experiment.tasks(experiment.id)[0].latest_job  # type: ignore
                 assert job is not None
                 exit_code = job.status.exit_code
                 last_timestamp = util.display_logs(
@@ -443,7 +442,7 @@ def run(
             experiment = beaker.experiment.wait_for(
                 experiment, timeout=timeout if timeout > 0 else None
             )[0]
-            job = beaker.experiment.tasks(experiment)[0].latest_job
+            job = beaker.experiment.tasks(experiment)[0].latest_job  # type: ignore
             assert job is not None
             exit_code = job.status.exit_code
     except (KeyboardInterrupt, TermInterrupt, JobTimeoutError) as exc:

--- a/gantry/common/constants.py
+++ b/gantry/common/constants.py
@@ -1,7 +1,5 @@
 DEFAULT_IMAGE = "ai2/conda"
 
-DEFAULT_CLUSTER = "ai2/general-cirrascale"
-
 ENTRYPOINT = "entrypoint.sh"
 
 GITHUB_TOKEN_SECRET = "GITHUB_TOKEN"
@@ -16,7 +14,7 @@ RESULTS_DIR = "/results"
 
 METRICS_FILE = f"{RESULTS_DIR}/metrics.json"
 
-NFS_MOUNT = "/net/nfs.cirrascale"
+NFS_MOUNT = "/net/nfs"
 
 NFS_SUPPORTED_CLUSTERS = {
     "ai2/allennlp-cirrascale",

--- a/gantry/common/util.py
+++ b/gantry/common/util.py
@@ -260,7 +260,7 @@ def build_experiment_spec(
             resources=task_resources,
             priority=priority,
         )
-        .with_constraint(cluster=[clusters] if isinstance(clusters, str) else clusters)
+        .with_constraint(cluster=clusters)
         .with_env_var(name="GANTRY_VERSION", value=VERSION)
         .with_env_var(name="GITHUB_TOKEN", secret=gh_token_secret)
         .with_env_var(name="GITHUB_REPO", value=f"{github_account}/{github_repo}")


### PR DESCRIPTION
- Adds `--priority` option to set the number of jobs.
- By default jobs will be submitted to all on-premise clusters as preemptible.