### PR TITLE
Improve error message when `--venv` is a path that doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Provide a more useful error message when you pass a path to `--venv` and that path doesn't exist.
+
 ## [v0.17.1](https://github.com/allenai/beaker-gantry/releases/tag/v0.17.1) - 2023-07-12
 
 ### Fixed

--- a/gantry/entrypoint.sh
+++ b/gantry/entrypoint.sh
@@ -72,7 +72,7 @@ if [[ -z "$PIP_REQUIREMENTS_FILE" ]]; then
     PIP_REQUIREMENTS_FILE="${{ PIP_REQUIREMENTS_FILE }}"
 fi
 
-if conda activate $VENV_NAME &>/dev/null; then
+if conda activate $VENV_NAME; then
     echo "[GANTRY] Using existing conda environment '$VENV_NAME'"
     # The virtual environment already exists. Possibly update it based on an environment file.
     if [[ -f "$CONDA_ENV_FILE" ]]; then

--- a/gantry/entrypoint.sh
+++ b/gantry/entrypoint.sh
@@ -72,6 +72,14 @@ if [[ -z "$PIP_REQUIREMENTS_FILE" ]]; then
     PIP_REQUIREMENTS_FILE="${{ PIP_REQUIREMENTS_FILE }}"
 fi
 
+# Check if VENV_NAME is a path. If so, it should exist.
+if [[ "$VENV_NAME" == */* ]]; then
+    if [[ ! -d "$VENV_NAME" ]]; then
+        echo >&2 "error: venv '$VENV_NAME' looks like a path but it doesn't exist"
+        exit 1
+    fi
+fi
+
 if conda activate $VENV_NAME; then
     echo "[GANTRY] Using existing conda environment '$VENV_NAME'"
     # The virtual environment already exists. Possibly update it based on an environment file.


### PR DESCRIPTION
See https://beaker.org/api/v3/jobs/01H5WY84K2MN0540WPD8DKAAKN/logs?tail=2

FYI @mukhal 