### PR TITLE
add `--no-python` flag, don't cancel experiment on keyboard interrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `--no-python` flag to skip setting up a Python environment entirely.
 
+### Changed
+
+- Gantry no longer cancels an experiment on keyboard interrupt.
+
 ## [v0.23.2](https://github.com/allenai/beaker-gantry/releases/tag/v0.23.2) - 2024-05-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `--no-python` flag to skip setting up a Python environment entirely.
+
 ## [v0.23.2](https://github.com/allenai/beaker-gantry/releases/tag/v0.23.2) - 2024-05-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `--no-python` flag to skip setting up a Python environment entirely.
+- Added `GANTRY_TASK_NAME` runtime environment variable, which will always match the `--task-name` argument.
 
 ### Changed
 

--- a/gantry/__main__.py
+++ b/gantry/__main__.py
@@ -607,8 +607,8 @@ def run(
             assert job is not None
     except (KeyboardInterrupt, TermInterrupt, JobTimeoutError) as exc:
         print_stderr(f"[red][bold]{exc.__class__.__name__}:[/] [i]{exc}[/][/]")
-        beaker.experiment.stop(experiment)
-        print_stderr("[yellow]Experiment cancelled.[/]")
+        #  beaker.experiment.stop(experiment)
+        #  print_stderr("[yellow]Experiment cancelled.[/]")
         sys.exit(1)
 
     util.display_results(beaker, experiment, job)

--- a/gantry/__main__.py
+++ b/gantry/__main__.py
@@ -284,6 +284,11 @@ def follow(experiment: str):
     help="""Override the default installation command, e.g. '--install "python setup.py install"'""",
 )
 @click.option(
+    "--no-python",
+    is_flag=True,
+    help="""If set, gantry will skip setting up a Python environment altogether.""",
+)
+@click.option(
     "--replicas",
     type=int,
     help="""The number of task replicas to run.""",
@@ -356,6 +361,7 @@ def run(
     save_spec: Optional[PathOrStr] = None,
     priority: Optional[str] = None,
     install: Optional[str] = None,
+    no_python: bool = False,
     replicas: Optional[int] = None,
     leader_selection: bool = False,
     host_networking: bool = False,
@@ -506,6 +512,7 @@ def run(
         env_secrets=env_secrets,
         priority=priority,
         install=install,
+        no_python=no_python,
         replicas=replicas,
         leader_selection=leader_selection,
         host_networking=host_networking or (bool(replicas) and leader_selection),

--- a/gantry/__main__.py
+++ b/gantry/__main__.py
@@ -612,8 +612,9 @@ def run(
         sys.exit(1)
     except KeyboardInterrupt as exc:
         print_stderr(f"[red][bold]{exc.__class__.__name__}:[/] [i]{exc}[/][/]")
+        print(f"See the experiment at {beaker.experiment.url(experiment)}")
         print_stderr(
-            f"[yellow]To cancel the experiment, run 'beaker experiment stop {experiment.id}'.[/]"
+            f"[yellow]To cancel the experiment, run:\n[i]$ beaker experiment stop {experiment.id}[/][/]"
         )
         sys.exit(1)
 

--- a/gantry/__main__.py
+++ b/gantry/__main__.py
@@ -605,10 +605,16 @@ def run(
             )[0]
             job = beaker.experiment.tasks(experiment)[0].latest_job  # type: ignore
             assert job is not None
-    except (KeyboardInterrupt, TermInterrupt, JobTimeoutError) as exc:
+    except (TermInterrupt, JobTimeoutError) as exc:
         print_stderr(f"[red][bold]{exc.__class__.__name__}:[/] [i]{exc}[/][/]")
-        #  beaker.experiment.stop(experiment)
-        #  print_stderr("[yellow]Experiment cancelled.[/]")
+        beaker.experiment.stop(experiment)
+        print_stderr("[yellow]Experiment cancelled.[/]")
+        sys.exit(1)
+    except KeyboardInterrupt as exc:
+        print_stderr(f"[red][bold]{exc.__class__.__name__}:[/] [i]{exc}[/][/]")
+        print_stderr(
+            f"[yellow]To cancel the experiment, run 'beaker experiment stop {experiment.id}'.[/]"
+        )
         sys.exit(1)
 
     util.display_results(beaker, experiment, job)

--- a/gantry/util.py
+++ b/gantry/util.py
@@ -300,6 +300,7 @@ def ensure_datasets(beaker: Beaker, *datasets: str) -> List[Tuple[str, Optional[
 
 
 def build_experiment_spec(
+    *,
     task_name: str,
     clusters: List[str],
     task_resources: TaskResources,
@@ -351,6 +352,7 @@ def build_experiment_spec(
         .with_env_var(name="GANTRY_VERSION", value=VERSION)
         .with_env_var(name="GITHUB_REPO", value=f"{github_account}/{github_repo}")
         .with_env_var(name="GIT_REF", value=git_ref)
+        .with_env_var(name="GANTRY_TASK_NAME", value=task_name)
         .with_dataset("/gantry", beaker=entrypoint_dataset)
     )
 

--- a/gantry/util.py
+++ b/gantry/util.py
@@ -322,6 +322,7 @@ def build_experiment_spec(
     env_secrets: Optional[List[Tuple[str, str]]] = None,
     priority: Optional[Union[str, Priority]] = None,
     install: Optional[str] = None,
+    no_python: bool = False,
     replicas: Optional[int] = None,
     leader_selection: bool = False,
     host_networking: bool = False,
@@ -371,40 +372,43 @@ def build_experiment_spec(
     for name, secret in env_secrets or []:
         task_spec = task_spec.with_env_var(name=name, secret=secret)
 
-    if conda is not None:
-        task_spec = task_spec.with_env_var(
-            name="CONDA_ENV_FILE",
-            value=str(conda),
-        )
-    elif Path(constants.CONDA_ENV_FILE).is_file():
-        task_spec = task_spec.with_env_var(
-            name="CONDA_ENV_FILE",
-            value=constants.CONDA_ENV_FILE,
-        )
-    elif Path(constants.CONDA_ENV_FILE_ALTERNATE).is_file():
-        task_spec = task_spec.with_env_var(
-            name="CONDA_ENV_FILE",
-            value=constants.CONDA_ENV_FILE_ALTERNATE,
-        )
+    if no_python:
+        task_spec = task_spec.with_env_var(name="NO_PYTHON", value="1")
     else:
-        task_spec = task_spec.with_env_var(
-            name="PYTHON_VERSION", value=".".join(platform.python_version_tuple()[:-1])
-        )
+        if conda is not None:
+            task_spec = task_spec.with_env_var(
+                name="CONDA_ENV_FILE",
+                value=str(conda),
+            )
+        elif Path(constants.CONDA_ENV_FILE).is_file():
+            task_spec = task_spec.with_env_var(
+                name="CONDA_ENV_FILE",
+                value=constants.CONDA_ENV_FILE,
+            )
+        elif Path(constants.CONDA_ENV_FILE_ALTERNATE).is_file():
+            task_spec = task_spec.with_env_var(
+                name="CONDA_ENV_FILE",
+                value=constants.CONDA_ENV_FILE_ALTERNATE,
+            )
+        else:
+            task_spec = task_spec.with_env_var(
+                name="PYTHON_VERSION", value=".".join(platform.python_version_tuple()[:-1])
+            )
 
-    if pip is not None:
-        task_spec = task_spec.with_env_var(
-            name="PIP_REQUIREMENTS_FILE",
-            value=str(pip),
-        )
+        if pip is not None:
+            task_spec = task_spec.with_env_var(
+                name="PIP_REQUIREMENTS_FILE",
+                value=str(pip),
+            )
 
-    if venv is not None:
-        task_spec = task_spec.with_env_var(
-            name="VENV_NAME",
-            value=venv,
-        )
+        if venv is not None:
+            task_spec = task_spec.with_env_var(
+                name="VENV_NAME",
+                value=venv,
+            )
 
-    if install is not None:
-        task_spec = task_spec.with_env_var(name="INSTALL_CMD", value=install)
+        if install is not None:
+            task_spec = task_spec.with_env_var(name="INSTALL_CMD", value=install)
 
     if (
         nfs is None


### PR DESCRIPTION
- Adds a new flag `--no-python` to `gantry run` that tells gantry to completely skip building a Python environment. This is useful of course for non-Python jobs, or jobs where the Python environment is already built into the image.
- Hitting CTRL-C while following a job with `gantry run` will no longer cancel the Beaker experiment. Instead it will just print out the `beaker` command you can use to cancel the experiment before exiting.
- Adds a runtime environment `GANTRY_TASK_NAME` which will always match the `--task-name` option to `gantry run`.