### PR TITLE
only split run command flags once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Made parsing env vars, secrets, and mounts more robust.
+
 ## [v1.8.0](https://github.com/allenai/beaker-gantry/releases/tag/v1.8.0) - 2024-07-14
 
 ### Added

--- a/gantry/commands/run.py
+++ b/gantry/commands/run.py
@@ -384,7 +384,7 @@ def run(
     env_vars = []
     for e in env or []:
         try:
-            env_name, val = e.split("=")
+            env_name, val = e.split("=", 1)
         except ValueError:
             raise ValueError("Invalid --env option: {e}")
         env_vars.append((env_name, val))
@@ -392,7 +392,7 @@ def run(
     env_secrets = []
     for e in env_secret or []:
         try:
-            env_secret_name, secret = e.split("=")
+            env_secret_name, secret = e.split("=", 1)
         except ValueError:
             raise ValueError(f"Invalid --env-secret option: '{e}'")
         env_secrets.append((env_secret_name, secret))
@@ -400,7 +400,7 @@ def run(
     mounts = []
     for m in mount or []:
         try:
-            source, target = m.split(":")
+            source, target = m.split(":", 1)
         except ValueError:
             raise ValueError(f"Invalid --mount option: '{m}'")
         mounts.append((source, target))
@@ -408,7 +408,7 @@ def run(
     weka_buckets = []
     for m in weka or []:
         try:
-            source, target = m.split(":")
+            source, target = m.split(":", 1)
         except ValueError:
             raise ValueError(f"Invalid --weka option: '{m}'")
         weka_buckets.append((source, target))


### PR DESCRIPTION
I ran into an issue trying to set an env variable that contained an equal sign. Probably safe to guard againt mounts and buckets containing colons as well.