### PR TITLE
Make arg parsing more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Made args parsing more robust to catch the scenario where a value is accidentally provided to a flag option.
+
 ## [v1.14.0](https://github.com/allenai/beaker-gantry/releases/tag/v1.14.0) - 2025-03-19
 
 ### Added

--- a/gantry/commands/run.py
+++ b/gantry/commands/run.py
@@ -796,7 +796,8 @@ def validate_args(arg: Tuple[str, ...]):
     invalid_args = arg[: -len(given_args)]
     if invalid_args:
         raise ConfigurationError(
-            f"Invalid CLI option(s), found extra arguments before the '--': "
+            f"Invalid options, found extra arguments before the '--': "
             f"{', '.join([repr(s) for s in invalid_args])}.\n"
+            "Hint: you might be trying to pass a value to a FLAG option.\n"
             "Try 'gantry run --help' for help."
         )

--- a/gantry/commands/run.py
+++ b/gantry/commands/run.py
@@ -341,10 +341,8 @@ def run(
 
     $ gantry run --name 'hello-world' -- python -c 'print("Hello, World!")'
     """
-    if not arg:
-        raise ConfigurationError(
-            "[ARGS]... are required! For example:\n$ gantry run -- python -c 'print(\"Hello, World!\")'"
-        )
+
+    validate_args(arg)
 
     if beaker_image is None and docker_image is None:
         beaker_image = constants.DEFAULT_IMAGE
@@ -779,3 +777,26 @@ def ensure_datasets(beaker: Beaker, *datasets: str) -> List[Tuple[str, Optional[
         dataset_id = beaker.dataset.get(dataset_name).id
         out.append((dataset_id, sub_path, path))
     return out
+
+
+def validate_args(arg: Tuple[str, ...]):
+    if not arg:
+        raise ConfigurationError(
+            "[ARGS]... are required! For example:\n$ gantry run -- python -c 'print(\"Hello, World!\")'"
+        )
+
+    try:
+        arg_index = sys.argv.index("--")
+    except ValueError:
+        raise ConfigurationError("[ARGS]... are required and must all come after '--'")
+
+    # NOTE: if a value was accidentally provided to a flag, like '--preemptible false', click will
+    # surprisingly add that value to the args. So we do a check here for that situation.
+    given_args = sys.argv[arg_index + 1 :]
+    invalid_args = arg[: -len(given_args)]
+    if invalid_args:
+        raise ConfigurationError(
+            f"Invalid CLI option(s), found extra arguments before the '--': "
+            f"{', '.join([repr(s) for s in invalid_args])}.\n"
+            "Try 'gantry run --help' for help."
+        )


### PR DESCRIPTION
@viking-sudo-rm reported:

> I was launching a job like the following:
> ```
> echo "noise-scale-step$STEP" | gantry run \
>  --workspace ai2/olmo-batchsize \
>  --budget ai2/oe-training \
>  --cluster $CLUSTER \
>  --priority "high" \
>  --preemptible "false" \
>  --gpus $GPUS \
>  --weka oe-training-default:/weka/oe-training-default \
>  -- python noise_scale.py $1 $2 \
>  --microbatch-size $MICROBATCH_SIZE \
>  --small-batch-size $SMALL_BATCH_SIZE \
>  --large-batch-size $LARGE_BATCH_SIZE \
>  --n-batches $N_BATCHES \
>  --step $STEP \
>  --no-data-parallel
> ```
> Turns out the issue was `--preemptible "false"`. The extra keyword was causing gantry to interpret my beaker command as `false python noise_scale.py …`

This is quirk of `click`, so I've added an extra check to catch this situation which will raise an error like this:

![image](https://github.com/user-attachments/assets/f416966c-6180-44c5-a029-229ddf7ddf3b)
