### PR TITLE
Automatically configure NCCL for TCPXO on Augusta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- When `--install` option is a shell script, it will now be `source`-ed instead `eval`-ed so that environment variables set from the script will be set in the main process.
+- Gantry will automatically configure NCCL for TCPXO when running multi-node jobs on Augusta so you don't have to set all of the environment variables document here: https://beaker-docs.apps.allenai.org/compute/augusta.html#distributed-workloads. You can skip this in case you want to configure TCPXO differently by using the flag `--skip-tcpxo-setup`.
+
 ## [v2.5.0](https://github.com/allenai/beaker-gantry/releases/tag/v2.5.0) - 2025-06-03
 
 ### Added

--- a/gantry/api.py
+++ b/gantry/api.py
@@ -155,6 +155,7 @@ def launch_experiment(
     preemptible: Optional[bool] = None,
     retries: Optional[int] = None,
     results: str = constants.RESULTS_DIR,
+    skip_tcpxo_setup: bool = False,
 ):
     """
     Launch an experiment on Beaker. Same as the ``gantry run`` command.
@@ -373,6 +374,7 @@ def launch_experiment(
             preemptible=preemptible,
             retries=retries,
             results=results,
+            skip_tcpxo_setup=skip_tcpxo_setup,
         )
 
         if save_spec:
@@ -502,6 +504,7 @@ def _build_experiment_spec(
     preemptible: Optional[bool] = None,
     retries: Optional[int] = None,
     results: str = constants.RESULTS_DIR,
+    skip_tcpxo_setup: bool = False,
 ):
     task_spec = (
         BeakerTaskSpec.new(
@@ -541,6 +544,9 @@ def _build_experiment_spec(
 
     if gh_token_secret is not None:
         task_spec = task_spec.with_env_var(name="GITHUB_TOKEN", secret=gh_token_secret)
+
+    if skip_tcpxo_setup:
+        task_spec = task_spec.with_env_var(name="GANTRY_SKIP_TCPXO_SETUP", value="1")
 
     for name, val in env or []:
         task_spec = task_spec.with_env_var(name=name, value=val)

--- a/gantry/commands/run.py
+++ b/gantry/commands/run.py
@@ -271,6 +271,15 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
     If set, jobs in the replicated task will wait this long to start until all other jobs are also ready.
     """,
 )
+@optgroup.option(
+    "--skip-tcpxo-setup",
+    is_flag=True,
+    help="""By default Gantry will configure NCCL for TCPXO when running multi-node job on Augusta,
+    but you can use this flag to skip that step if you need a custom configuration.
+    If you do use this flag, you'll probably need to follow all of the steps documented here:
+
+    https://beaker-docs.allen.ai/compute/augusta.html#distributed-workloads""",
+)
 @new_optgroup("Python")
 @optgroup.option(
     "--conda",


### PR DESCRIPTION
With this Gantry will automatically configure NCCL to use TCPXO for multi-node runs on Augusta, unless the flag `--skip-tcpxo-setup` is used. 