### PR TITLE
Make installing/upgrading pip more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed default beaker image to [`petew/gantry`](https://beaker.allen.ai/orgs/ai2/workspaces/gantry-testing/images).
 
+### Fixed
+
+- Made installing/upgrading the `pip` package manager more robust.
+
 ## [v2.7.1](https://github.com/allenai/beaker-gantry/releases/tag/v2.7.1) - 2025-06-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `-f/--follow` option to `gantry logs`.
+- Added `--python-version` option to `gantry run` for overriding the default Python version to use.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Made installing/upgrading the `pip` package manager more robust.
+- Made installing/upgrading the `pip` package manager more robust, and added a check to ensure the pip version being used is in the active virtual environment.
 
 ## [v2.7.1](https://github.com/allenai/beaker-gantry/releases/tag/v2.7.1) - 2025-06-25
 

--- a/gantry/api.py
+++ b/gantry/api.py
@@ -156,6 +156,7 @@ def launch_experiment(
     retries: Optional[int] = None,
     results: str = constants.RESULTS_DIR,
     skip_tcpxo_setup: bool = False,
+    python_version: Optional[str] = None,
 ):
     """
     Launch an experiment on Beaker. Same as the ``gantry run`` command.
@@ -375,6 +376,7 @@ def launch_experiment(
             retries=retries,
             results=results,
             skip_tcpxo_setup=skip_tcpxo_setup,
+            python_version=python_version,
         )
 
         if save_spec:
@@ -505,6 +507,7 @@ def _build_experiment_spec(
     retries: Optional[int] = None,
     results: str = constants.RESULTS_DIR,
     skip_tcpxo_setup: bool = False,
+    python_version: Optional[str] = None,
 ):
     task_spec = (
         BeakerTaskSpec.new(
@@ -575,7 +578,10 @@ def _build_experiment_spec(
                 )
             else:
                 task_spec = task_spec.with_env_var(
-                    name="PYTHON_VERSION", value=".".join(platform.python_version_tuple()[:-1])
+                    name="PYTHON_VERSION",
+                    value=python_version
+                    if python_version is not None
+                    else ".".join(platform.python_version_tuple()[:-1]),
                 )
 
             if venv is not None:

--- a/gantry/commands/run.py
+++ b/gantry/commands/run.py
@@ -293,6 +293,12 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
     help="""The name of an existing conda environment on the image to use.""",
 )
 @optgroup.option(
+    "--python-version",
+    type=str,
+    help="""The default Python version to use when constructing a new Python environment (e.g. --python-version='3.12').
+    This won't be applied if --venv is specified or a conda environment file is used.""",
+)
+@optgroup.option(
     "--pip",
     type=click.Path(exists=True, dir_okay=False),
     help=f"""Path to a PIP requirements file for reconstructing your Python environment.

--- a/gantry/entrypoint.sh
+++ b/gantry/entrypoint.sh
@@ -163,10 +163,25 @@ function should_use_conda {
 
 function ensure_pip {
     log_info "Installing/upgrading PIP package manager..."
+
+    # Use 'ensurepip' if necessary to install pip.
     if ! command -v pip &> /dev/null; then
         capture_logs "install_pip.log" python -m ensurepip
     fi
+
+    # Upgrade pip.
     capture_logs "upgrade_pip.log" pip install --upgrade pip
+
+    # Validate that pip is installed to the active Python environment.
+    if command -v dirname &> /dev/null; then
+        python_location=$(dirname "$(which python)")
+        pip_location=$(dirname "$(which pip)")
+        if [[ "$python_location" != "$pip_location" ]]; then
+            log_error "installing/upgrading PIP failed, install location '$pip_location' doesn't match python location '$python_location'"
+            exit 1
+        fi
+    fi
+
     log_info "Done. Using $(pip --version)"
 }
 

--- a/gantry/entrypoint.sh
+++ b/gantry/entrypoint.sh
@@ -162,13 +162,12 @@ function should_use_conda {
 }
 
 function ensure_pip {
-    log_info "Install/upgrading PIP package manager..."
+    log_info "Installing/upgrading PIP package manager..."
     if ! command -v pip &> /dev/null; then
-        capture_logs "ensure_pip.log" python -m ensurepip --upgrade
-    else
-        capture_logs "ensure_pip.log" pip install --upgrade pip
+        capture_logs "install_pip.log" python -m ensurepip
     fi
-    log_info "Done."
+    capture_logs "upgrade_pip.log" pip install --upgrade pip
+    log_info "Done. Using $(pip --version)"
 }
 
 echo -e "\e[36m\e[1m


### PR DESCRIPTION
@finbarrtimbers reported an issue from [this run](https://beaker.allen.ai/orgs/ai2/workspaces/oe-eval/work/01JZ3BBCTTRCA2Q5X2YY2Z7VZV?taskId=01JZ3BBCV1NKZP536QBS6BHB2Q&jobId=01JZ3BBCZ53VJX68G5WT6HC3HD) where site packages installed via `pip` weren't found at runtime. After [some investigation](https://allenai.slack.com/archives/C6MN19S05/p1751334187079899) we found out that running `python -m ensurepip --upgrade` in a conda environment could result in installing a system-wide version of `pip` that would take precedence over the version in the environment.

So with this PR we'll only call `python -m ensurepip` (never with the `--upgrade` option), and have an additional check to ensure the version of `pip` being used is inside the conda/virtual environment.

This also adds a `--python-version` option to `gantry run` for overriding the default Python version to use. 