### PR TITLE
Uv support via flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ pip-wheel-metadata/
 .venv/
 .vscode/
 /*.iml
-
+uv.lock
 
 # jupyter notebooks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `--uv` option that enables using `uv` to install project requirements. Uses a shared uv cache if a weka bucket is specified.
+
 ## [v2.8.0](https://github.com/allenai/beaker-gantry/releases/tag/v2.8.0) - 2025-07-07
 
 ### Added

--- a/gantry/api.py
+++ b/gantry/api.py
@@ -307,7 +307,7 @@ def launch_experiment(
             if not uv_cache_already_set:
                 first_weka_target = Path(weka_buckets[0][1])
                 uv_cache_dir = first_weka_target / ".cache" / "uv"
-                env_vars_to_use.append(("UV_CACHE_DIR", str(uv_cache_dir)))
+                # env_vars_to_use.append(("UV_CACHE_DIR", str(uv_cache_dir)))
 
         # Validate clusters.
         if clusters or gpu_types:

--- a/gantry/api.py
+++ b/gantry/api.py
@@ -182,13 +182,9 @@ def launch_experiment(
     if beaker_image is None and docker_image is None:
         beaker_image = constants.DEFAULT_IMAGE
     elif (beaker_image is None) == (docker_image is None):
-        raise ConfigurationError(
-            "Either --beaker-image or --docker-image must be specified, but not both."
-        )
+        raise ConfigurationError("Either --beaker-image or --docker-image must be specified, but not both.")
 
-    task_resources = BeakerTaskResources(
-        cpu_count=cpus, gpu_count=gpus, memory=memory, shared_memory=shared_memory
-    )
+    task_resources = BeakerTaskResources(cpu_count=cpus, gpu_count=gpus, memory=memory, shared_memory=shared_memory)
 
     # Get git information.
     git_config = GitRepoState.from_env(ref=ref, branch=branch)
@@ -333,9 +329,7 @@ def launch_experiment(
                 if matching_clusters:
                     final_clusters.extend(matching_clusters)
                 elif clusters:
-                    raise ConfigurationError(
-                        f"cluster '{og_pat}' did not match any Beaker clusters"
-                    )
+                    raise ConfigurationError(f"cluster '{og_pat}' did not match any Beaker clusters")
                 elif gpu_types:
                     raise ConfigurationError(
                         f"""GPU type specs "{'", "'.join(gpu_types)}" did not match any Beaker clusters"""
@@ -572,13 +566,9 @@ def _build_experiment_spec(
         if conda is not None:
             task_spec = task_spec.with_env_var(name="CONDA_ENV_FILE", value=str(conda))
         elif Path(constants.CONDA_ENV_FILE).is_file():
-            task_spec = task_spec.with_env_var(
-                name="CONDA_ENV_FILE", value=constants.CONDA_ENV_FILE
-            )
+            task_spec = task_spec.with_env_var(name="CONDA_ENV_FILE", value=constants.CONDA_ENV_FILE)
         elif Path(constants.CONDA_ENV_FILE_ALTERNATE).is_file():
-            task_spec = task_spec.with_env_var(
-                name="CONDA_ENV_FILE", value=constants.CONDA_ENV_FILE_ALTERNATE
-            )
+            task_spec = task_spec.with_env_var(name="CONDA_ENV_FILE", value=constants.CONDA_ENV_FILE_ALTERNATE)
         else:
             # Always set PYTHON_VERSION for both conda and uv
             task_spec = task_spec.with_env_var(
@@ -594,8 +584,6 @@ def _build_experiment_spec(
             task_spec = task_spec.with_env_var(name="PIP_REQUIREMENTS_FILE", value=str(pip))
         if uv is not None:
             task_spec = task_spec.with_env_var(name="USE_UV", value="1")
-            if uv:  # If uv has a value (not just empty string from flag)
-                task_spec = task_spec.with_env_var(name="UV_ARGS", value=uv)
         if install is not None:
             task_spec = task_spec.with_env_var(name="INSTALL_CMD", value=install)
 
@@ -700,9 +688,7 @@ def follow_workload(
             for job_log in beaker.job.logs(job, tail_lines=10 if tail else None, follow=True):
                 console.print(job_log.message.decode(), highlight=False, markup=False)
                 if timeout > 0 and (time.monotonic() - start_time) > timeout:
-                    raise BeakerJobTimeoutError(
-                        f"Timed out while waiting for job '{job.id}' to finish"
-                    )
+                    raise BeakerJobTimeoutError(f"Timed out while waiting for job '{job.id}' to finish")
 
             print()
             rich.get_console().rule("End logs")

--- a/gantry/api.py
+++ b/gantry/api.py
@@ -300,6 +300,15 @@ def launch_experiment(
                 raise ValueError(f"Invalid --weka option: '{m}'")
             weka_buckets.append((source, target))
 
+        # Add UV_CACHE_DIR env var pointing to the first weka bucket so that
+        # multiple users can share the same uv cache directory.
+        if weka_buckets:
+            uv_cache_already_set = any(name == "UV_CACHE_DIR" for name, _ in env_vars_to_use)
+            if not uv_cache_already_set:
+                first_weka_target = Path(weka_buckets[0][1])
+                uv_cache_dir = first_weka_target / ".cache" / "uv"
+                env_vars_to_use.append(("UV_CACHE_DIR", str(uv_cache_dir)))
+
         # Validate clusters.
         if clusters or gpu_types:
             cl_objects = list(beaker.cluster.list())

--- a/gantry/api.py
+++ b/gantry/api.py
@@ -585,7 +585,10 @@ def _build_experiment_spec(
         else:
             # Always set PYTHON_VERSION for both conda and uv
             task_spec = task_spec.with_env_var(
-                name="PYTHON_VERSION", value=".".join(platform.python_version_tuple()[:-1])
+                name="PYTHON_VERSION",
+                value=python_version
+                if python_version is not None
+                else ".".join(platform.python_version_tuple()[:-1]),
             )
 
         if venv is not None:

--- a/gantry/api.py
+++ b/gantry/api.py
@@ -182,9 +182,13 @@ def launch_experiment(
     if beaker_image is None and docker_image is None:
         beaker_image = constants.DEFAULT_IMAGE
     elif (beaker_image is None) == (docker_image is None):
-        raise ConfigurationError("Either --beaker-image or --docker-image must be specified, but not both.")
+        raise ConfigurationError(
+            "Either --beaker-image or --docker-image must be specified, but not both."
+        )
 
-    task_resources = BeakerTaskResources(cpu_count=cpus, gpu_count=gpus, memory=memory, shared_memory=shared_memory)
+    task_resources = BeakerTaskResources(
+        cpu_count=cpus, gpu_count=gpus, memory=memory, shared_memory=shared_memory
+    )
 
     # Get git information.
     git_config = GitRepoState.from_env(ref=ref, branch=branch)
@@ -329,7 +333,9 @@ def launch_experiment(
                 if matching_clusters:
                     final_clusters.extend(matching_clusters)
                 elif clusters:
-                    raise ConfigurationError(f"cluster '{og_pat}' did not match any Beaker clusters")
+                    raise ConfigurationError(
+                        f"cluster '{og_pat}' did not match any Beaker clusters"
+                    )
                 elif gpu_types:
                     raise ConfigurationError(
                         f"""GPU type specs "{'", "'.join(gpu_types)}" did not match any Beaker clusters"""
@@ -566,9 +572,13 @@ def _build_experiment_spec(
         if conda is not None:
             task_spec = task_spec.with_env_var(name="CONDA_ENV_FILE", value=str(conda))
         elif Path(constants.CONDA_ENV_FILE).is_file():
-            task_spec = task_spec.with_env_var(name="CONDA_ENV_FILE", value=constants.CONDA_ENV_FILE)
+            task_spec = task_spec.with_env_var(
+                name="CONDA_ENV_FILE", value=constants.CONDA_ENV_FILE
+            )
         elif Path(constants.CONDA_ENV_FILE_ALTERNATE).is_file():
-            task_spec = task_spec.with_env_var(name="CONDA_ENV_FILE", value=constants.CONDA_ENV_FILE_ALTERNATE)
+            task_spec = task_spec.with_env_var(
+                name="CONDA_ENV_FILE", value=constants.CONDA_ENV_FILE_ALTERNATE
+            )
         else:
             # Always set PYTHON_VERSION for both conda and uv
             task_spec = task_spec.with_env_var(
@@ -688,7 +698,9 @@ def follow_workload(
             for job_log in beaker.job.logs(job, tail_lines=10 if tail else None, follow=True):
                 console.print(job_log.message.decode(), highlight=False, markup=False)
                 if timeout > 0 and (time.monotonic() - start_time) > timeout:
-                    raise BeakerJobTimeoutError(f"Timed out while waiting for job '{job.id}' to finish")
+                    raise BeakerJobTimeoutError(
+                        f"Timed out while waiting for job '{job.id}' to finish"
+                    )
 
             print()
             rich.get_console().rule("End logs")

--- a/gantry/api.py
+++ b/gantry/api.py
@@ -169,20 +169,26 @@ def launch_experiment(
             raise ConfigurationError("--no-python and --install='...' are mutually exclusive.")
         if pip:
             raise ConfigurationError("--pip='...' and --install='...' are mutually exclusive.")
-    
+
     # Validate Python environment options
     if uv is not None:
         if conda:
             raise ConfigurationError("--uv and --conda are mutually exclusive.")
         if no_conda:
-            raise ConfigurationError("--uv and --no-conda are mutually exclusive. UV manages its own Python environments.")
+            raise ConfigurationError(
+                "--uv and --no-conda are mutually exclusive. UV manages its own Python environments."
+            )
 
     if beaker_image is None and docker_image is None:
         beaker_image = constants.DEFAULT_IMAGE
     elif (beaker_image is None) == (docker_image is None):
-        raise ConfigurationError("Either --beaker-image or --docker-image must be specified, but not both.")
+        raise ConfigurationError(
+            "Either --beaker-image or --docker-image must be specified, but not both."
+        )
 
-    task_resources = BeakerTaskResources(cpu_count=cpus, gpu_count=gpus, memory=memory, shared_memory=shared_memory)
+    task_resources = BeakerTaskResources(
+        cpu_count=cpus, gpu_count=gpus, memory=memory, shared_memory=shared_memory
+    )
 
     # Get git information.
     git_config = GitRepoState.from_env(ref=ref, branch=branch)
@@ -327,7 +333,9 @@ def launch_experiment(
                 if matching_clusters:
                     final_clusters.extend(matching_clusters)
                 elif clusters:
-                    raise ConfigurationError(f"cluster '{og_pat}' did not match any Beaker clusters")
+                    raise ConfigurationError(
+                        f"cluster '{og_pat}' did not match any Beaker clusters"
+                    )
                 elif gpu_types:
                     raise ConfigurationError(
                         f"""GPU type specs "{'", "'.join(gpu_types)}" did not match any Beaker clusters"""
@@ -564,10 +572,15 @@ def _build_experiment_spec(
         if conda is not None:
             task_spec = task_spec.with_env_var(name="CONDA_ENV_FILE", value=str(conda))
         elif Path(constants.CONDA_ENV_FILE).is_file():
-            task_spec = task_spec.with_env_var(name="CONDA_ENV_FILE", value=constants.CONDA_ENV_FILE)
+            task_spec = task_spec.with_env_var(
+                name="CONDA_ENV_FILE", value=constants.CONDA_ENV_FILE
+            )
         elif Path(constants.CONDA_ENV_FILE_ALTERNATE).is_file():
-            task_spec = task_spec.with_env_var(name="CONDA_ENV_FILE", value=constants.CONDA_ENV_FILE_ALTERNATE)
+            task_spec = task_spec.with_env_var(
+                name="CONDA_ENV_FILE", value=constants.CONDA_ENV_FILE_ALTERNATE
+            )
         else:
+            # Always set PYTHON_VERSION for both conda and uv
             task_spec = task_spec.with_env_var(
                 name="PYTHON_VERSION", value=".".join(platform.python_version_tuple()[:-1])
             )
@@ -687,7 +700,9 @@ def follow_workload(
             for job_log in beaker.job.logs(job, tail_lines=10 if tail else None, follow=True):
                 console.print(job_log.message.decode(), highlight=False, markup=False)
                 if timeout > 0 and (time.monotonic() - start_time) > timeout:
-                    raise BeakerJobTimeoutError(f"Timed out while waiting for job '{job.id}' to finish")
+                    raise BeakerJobTimeoutError(
+                        f"Timed out while waiting for job '{job.id}' to finish"
+                    )
 
             print()
             rich.get_console().rule("End logs")

--- a/gantry/api.py
+++ b/gantry/api.py
@@ -567,6 +567,7 @@ def _build_experiment_spec(
 
     for name, secret in env_secrets or []:
         task_spec = task_spec.with_env_var(name=name, secret=secret)
+
     if no_python:
         task_spec = task_spec.with_env_var(name="NO_PYTHON", value="1")
     elif no_conda:
@@ -594,7 +595,6 @@ def _build_experiment_spec(
         if venv is not None:
             task_spec = task_spec.with_env_var(name="VENV_NAME", value=venv)
 
-    # Handle Python package installation options
     if not no_python:
         if pip is not None:
             task_spec = task_spec.with_env_var(name="PIP_REQUIREMENTS_FILE", value=str(pip))

--- a/gantry/commands/main.py
+++ b/gantry/commands/main.py
@@ -31,8 +31,8 @@ CLICK_COMMAND_DEFAULTS = {
 }
 
 
-def new_optgroup(name: str, **kwargs):
-    return optgroup.group(f"\n ❯❯❯ {name}", **kwargs)
+def new_optgroup(name: str):
+    return optgroup.group(f"\n ❯❯❯ {name}")
 
 
 def excepthook(exctype, value, tb):

--- a/gantry/commands/main.py
+++ b/gantry/commands/main.py
@@ -31,8 +31,8 @@ CLICK_COMMAND_DEFAULTS = {
 }
 
 
-def new_optgroup(name: str):
-    return optgroup.group(f"\n ❯❯❯ {name}")
+def new_optgroup(name: str, **kwargs):
+    return optgroup.group(f"\n ❯❯❯ {name}", **kwargs)
 
 
 def excepthook(exctype, value, tb):

--- a/gantry/commands/run.py
+++ b/gantry/commands/run.py
@@ -300,9 +300,7 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
 )
 @optgroup.option(
     "--uv",
-    default=None,
-    flag_value="",
-    type=str,
+    is_flag=True,
     help="""Use uv for Python package management. Will use `uv sync` to install packages, if a
     `pyproject.toml` file is present. Otherwise, it will use `uv pip install` to install packages.""",
 )

--- a/gantry/commands/run.py
+++ b/gantry/commands/run.py
@@ -26,7 +26,9 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
     help="""The Beaker workspace to use.
     If not specified, your default workspace will be used.""",
 )
-@optgroup.option("-b", "--budget", type=str, help="""The budget account to associate with the experiment.""")
+@optgroup.option(
+    "-b", "--budget", type=str, help="""The budget account to associate with the experiment."""
+)
 @optgroup.option("--group", "group_name", type=str, help="""A group to assign the experiment to.""")
 @new_optgroup("Launch settings")
 @optgroup.option(
@@ -232,7 +234,9 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
     jobs will default to preemptible.""",
     default=None,
 )
-@optgroup.option("--retries", type=int, help="""Specify the number of automatic retries for the experiment.""")
+@optgroup.option(
+    "--retries", type=int, help="""Specify the number of automatic retries for the experiment."""
+)
 @new_optgroup("Multi-node config")
 @optgroup.option(
     "--replicas",
@@ -254,8 +258,12 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
     When used with '--replicas INT', this allows the replicas to communicate with each
     other using their hostnames.""",
 )
-@optgroup.option("--propagate-failure", is_flag=True, help="""Stop the experiment if any task fails.""")
-@optgroup.option("--propagate-preemption", is_flag=True, help="""Stop the experiment if any task is preempted.""")
+@optgroup.option(
+    "--propagate-failure", is_flag=True, help="""Stop the experiment if any task fails."""
+)
+@optgroup.option(
+    "--propagate-preemption", is_flag=True, help="""Stop the experiment if any task is preempted."""
+)
 @optgroup.option(
     "--synchronized-start-timeout",
     type=str,

--- a/gantry/commands/run.py
+++ b/gantry/commands/run.py
@@ -26,9 +26,7 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
     help="""The Beaker workspace to use.
     If not specified, your default workspace will be used.""",
 )
-@optgroup.option(
-    "-b", "--budget", type=str, help="""The budget account to associate with the experiment."""
-)
+@optgroup.option("-b", "--budget", type=str, help="""The budget account to associate with the experiment.""")
 @optgroup.option("--group", "group_name", type=str, help="""A group to assign the experiment to.""")
 @new_optgroup("Launch settings")
 @optgroup.option(
@@ -234,9 +232,7 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
     jobs will default to preemptible.""",
     default=None,
 )
-@optgroup.option(
-    "--retries", type=int, help="""Specify the number of automatic retries for the experiment."""
-)
+@optgroup.option("--retries", type=int, help="""Specify the number of automatic retries for the experiment.""")
 @new_optgroup("Multi-node config")
 @optgroup.option(
     "--replicas",
@@ -258,12 +254,8 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
     When used with '--replicas INT', this allows the replicas to communicate with each
     other using their hostnames.""",
 )
-@optgroup.option(
-    "--propagate-failure", is_flag=True, help="""Stop the experiment if any task fails."""
-)
-@optgroup.option(
-    "--propagate-preemption", is_flag=True, help="""Stop the experiment if any task is preempted."""
-)
+@optgroup.option("--propagate-failure", is_flag=True, help="""Stop the experiment if any task fails.""")
+@optgroup.option("--propagate-preemption", is_flag=True, help="""Stop the experiment if any task is preempted.""")
 @optgroup.option(
     "--synchronized-start-timeout",
     type=str,
@@ -297,6 +289,13 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
     type=click.Path(exists=True, dir_okay=False),
     help=f"""Path to a PIP requirements file for reconstructing your Python environment.
     If not specified, '{constants.PIP_REQUIREMENTS_FILE}' will be used if it exists.""",
+)
+@optgroup.option(
+    "--uv",
+    default=None,
+    flag_value="",
+    type=str,
+    help="Use uv for Python package management. Optionally provide arguments like '--uv \"--all-extras --system\"'.",
 )
 @optgroup.option(
     "--install",

--- a/gantry/commands/run.py
+++ b/gantry/commands/run.py
@@ -301,8 +301,8 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
 @optgroup.option(
     "--uv",
     is_flag=True,
-    help="""Use uv for Python package management. Will use `uv sync` to install packages, if a
-    `pyproject.toml` file is present. Otherwise, it will use `uv pip install` to install packages.""",
+    help=f"""Use uv for Python package management. Will use `uv sync` to install packages, if a
+    `pyproject.toml` file is present. Otherwise, it will use `uv pip install -r {constants.PIP_REQUIREMENTS_FILE}` to install packages.""",
 )
 @optgroup.option(
     "--install",

--- a/gantry/commands/run.py
+++ b/gantry/commands/run.py
@@ -26,9 +26,7 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
     help="""The Beaker workspace to use.
     If not specified, your default workspace will be used.""",
 )
-@optgroup.option(
-    "-b", "--budget", type=str, help="""The budget account to associate with the experiment."""
-)
+@optgroup.option("-b", "--budget", type=str, help="""The budget account to associate with the experiment.""")
 @optgroup.option("--group", "group_name", type=str, help="""A group to assign the experiment to.""")
 @new_optgroup("Launch settings")
 @optgroup.option(
@@ -234,9 +232,7 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
     jobs will default to preemptible.""",
     default=None,
 )
-@optgroup.option(
-    "--retries", type=int, help="""Specify the number of automatic retries for the experiment."""
-)
+@optgroup.option("--retries", type=int, help="""Specify the number of automatic retries for the experiment.""")
 @new_optgroup("Multi-node config")
 @optgroup.option(
     "--replicas",
@@ -258,12 +254,8 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
     When used with '--replicas INT', this allows the replicas to communicate with each
     other using their hostnames.""",
 )
-@optgroup.option(
-    "--propagate-failure", is_flag=True, help="""Stop the experiment if any task fails."""
-)
-@optgroup.option(
-    "--propagate-preemption", is_flag=True, help="""Stop the experiment if any task is preempted."""
-)
+@optgroup.option("--propagate-failure", is_flag=True, help="""Stop the experiment if any task fails.""")
+@optgroup.option("--propagate-preemption", is_flag=True, help="""Stop the experiment if any task is preempted.""")
 @optgroup.option(
     "--synchronized-start-timeout",
     type=str,
@@ -303,7 +295,8 @@ from .main import CLICK_COMMAND_DEFAULTS, main, new_optgroup
     default=None,
     flag_value="",
     type=str,
-    help="Use uv for Python package management. Optionally provide arguments like '--uv \"--all-extras --system\"'.",
+    help="""Use uv for Python package management. Will use `uv sync` to install packages, if a
+    `pyproject.toml` file is present. Otherwise, it will use `uv pip install` to install packages.""",
 )
 @optgroup.option(
     "--install",

--- a/gantry/entrypoint.sh
+++ b/gantry/entrypoint.sh
@@ -305,41 +305,40 @@ if [[ -z "$NO_PYTHON" ]]; then
             log_info "Activating specified virtual environment '$VENV_NAME'..."
             source "$VENV_NAME/bin/activate"
             log_info "Done."
-        else
-            if [[ -n "$UV_CACHE_DIR" ]]; then
-                log_info "Using uv cache directory: $UV_CACHE_DIR"
-            fi
 
-            if [[ -f "pyproject.toml" ]]; then
-                log_info "Installing project dependencies with uv sync..."
-                if [[ -n "$UV_ARGS" ]]; then
-                    log_info "Running: uv sync $UV_ARGS"
-                    capture_logs "uv_sync.log" uv sync $UV_ARGS
-                else
-                    capture_logs "uv_sync.log" uv sync
-                fi
-                log_info "Done."
+        if [[ -n "$UV_CACHE_DIR" ]]; then
+            log_info "Using uv cache directory: $UV_CACHE_DIR"
+        fi
 
-                # Activate the virtual environment created by uv
-                if [[ -d ".venv" ]]; then
-                    log_info "Activating virtual environment..."
-                    source .venv/bin/activate
-                    log_info "Done."
-                fi
-            elif [[ -f "$PIP_REQUIREMENTS_FILE" ]]; then
-                # Create venv and install requirements
-                log_info "Creating virtual environment with uv..."
-                capture_logs "uv_venv_create.log" uv venv
-                source .venv/bin/activate
-
-                log_info "Installing packages from '$PIP_REQUIREMENTS_FILE' with uv..."
-                capture_logs "uv_pip_install.log" uv pip install -r "$PIP_REQUIREMENTS_FILE"
-                log_info "Done."
+        if [[ -f "pyproject.toml" ]]; then
+            log_info "Installing project dependencies with uv sync..."
+            if [[ -n "$UV_ARGS" ]]; then
+                log_info "Running: uv sync $UV_ARGS"
+                capture_logs "uv_sync.log" uv sync $UV_ARGS
             else
-                log_info "No dependency files found. Creating empty virtual environment..."
-                capture_logs "uv_venv_create.log" uv venv
-                source .venv/bin/activate
+                capture_logs "uv_sync.log" uv sync
             fi
+            log_info "Done."
+
+            # Activate the virtual environment created by uv
+            if [[ -d ".venv" ]]; then
+                log_info "Activating virtual environment..."
+                source .venv/bin/activate
+                log_info "Done."
+            fi
+        elif [[ -f "$PIP_REQUIREMENTS_FILE" ]]; then
+            # Create venv and install requirements
+            log_info "Creating virtual environment with uv..."
+            capture_logs "uv_venv_create.log" uv venv
+            source .venv/bin/activate
+
+            log_info "Installing packages from '$PIP_REQUIREMENTS_FILE' with uv..."
+            capture_logs "uv_pip_install.log" uv pip install -r "$PIP_REQUIREMENTS_FILE"
+            log_info "Done."
+        else
+            log_info "No dependency files found. Creating empty virtual environment..."
+            capture_logs "uv_venv_create.log" uv venv
+            source .venv/bin/activate
         fi
     elif should_use_conda; then
         ensure_conda

--- a/gantry/entrypoint.sh
+++ b/gantry/entrypoint.sh
@@ -274,7 +274,6 @@ if [[ -z "$NO_PYTHON" ]]; then
         if [[ -n "$PYTHON_VERSION" ]]; then
             log_info "Installing Python $PYTHON_VERSION with uv..."
             capture_logs "uv_python_install.log" uv python install "$PYTHON_VERSION"
-            log_info "Setting UV_PYTHON=$UV_PYTHON"
             export UV_PYTHON="$PYTHON_VERSION"
             log_info "Done."
         fi
@@ -382,18 +381,20 @@ if [[ -z "$NO_PYTHON" ]]; then
     fi
 
     if [[ -z "$INSTALL_CMD" ]]; then
-        if [[ -f 'setup.py' ]] || [[ -f 'pyproject.toml' ]] || [[ -f 'setup.cfg' ]]; then
-            log_info "Installing local project..."
-            if [[ -f "$PIP_REQUIREMENTS_FILE" ]]; then
-                capture_logs "pip_install.log" pip install . -r "$PIP_REQUIREMENTS_FILE"
-            else
-                capture_logs "pip_install.log" pip install .
+        if ! should_use_uv; then
+            if [[ -f 'setup.py' ]] || [[ -f 'pyproject.toml' ]] || [[ -f 'setup.cfg' ]]; then
+                log_info "Installing local project..."
+                if [[ -f "$PIP_REQUIREMENTS_FILE" ]]; then
+                    capture_logs "pip_install.log" pip install . -r "$PIP_REQUIREMENTS_FILE"
+                else
+                    capture_logs "pip_install.log" pip install .
+                fi
+                log_info "Done."
+            elif [[ -f "$PIP_REQUIREMENTS_FILE" ]]; then
+                log_info "Installing packages from '$PIP_REQUIREMENTS_FILE'..."
+                capture_logs "pip_install.log" pip install -r "$PIP_REQUIREMENTS_FILE"
+                log_info "Done."
             fi
-            log_info "Done."
-        elif [[ -f "$PIP_REQUIREMENTS_FILE" ]]; then
-            log_info "Installing packages from '$PIP_REQUIREMENTS_FILE'..."
-            capture_logs "pip_install.log" pip install -r "$PIP_REQUIREMENTS_FILE"
-            log_info "Done."
         fi
     elif [[ -f "$INSTALL_CMD" ]] && [[ "${INSTALL_CMD: -3}" == ".sh" ]]; then
         log_info "Sourcing install script '$INSTALL_CMD'..."

--- a/gantry/entrypoint.sh
+++ b/gantry/entrypoint.sh
@@ -289,6 +289,10 @@ if [[ -z "$NO_PYTHON" ]]; then
             source "$VENV_NAME/bin/activate"
             log_info "Done."
         else
+            if [[ -n "$UV_CACHE_DIR" ]]; then
+                log_info "Using uv cache directory: $UV_CACHE_DIR"
+            fi
+
             if [[ -f "pyproject.toml" ]]; then
                 log_info "Installing project dependencies with uv sync..."
                 if [[ -n "$UV_ARGS" ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ profile = "black"
 multi_line_output = 3
 
 [tool.ruff]
-line-length = 120
+line-length = 100
 
 [tool.ruff.lint]
 ignore = ["F403", "F405", "E501"]

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -194,3 +194,24 @@ def test_dry_run_with_replicas(workspace_name: str, run_name: str, tmp_path: Pat
     assert spec.tasks[0].propagate_failure is True
     assert spec.tasks[0].propagate_preemption is True
     assert spec.tasks[0].replicas == 4
+
+
+def test_dry_run_with_uv(workspace_name: str, run_name: str, tmp_path: Path):
+    spec_path = tmp_path / "spec.yaml"
+    result = subprocess.run(
+        _build_run_cmd(
+            workspace_name=workspace_name,
+            run_name=run_name,
+            spec_path=spec_path,
+            options=["--uv", "--weka=oe-training-default:/weka/oe-training-default"],
+        ),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+    # Make sure spec is valid.
+    spec = BeakerExperimentSpec.from_file(spec_path)
+    assert spec.tasks[0].env_vars is not None
+    assert any(env_var.name == "USE_UV" for env_var in spec.tasks[0].env_vars)
+    assert any(env_var.name == "UV_CACHE_DIR" for env_var in spec.tasks[0].env_vars)


### PR DESCRIPTION
Supports using `--uv` to trigger installation of a python environment using `uv`. Uses `uv sync` if a pyproject.toml is present, otherwise uses `uv pip install`. If any special uv flags are needed (like `--all-extras`) then for now users should just use the `--install` command.

If the `--uv` flag is specified and a weka bucket is available will use a shared uv cache in the weka bucket.