### PR TITLE
Add cmake to default docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+ - Added `cmake` to the default docker image.
+
 ## [v2.8.0](https://github.com/allenai/beaker-gantry/releases/tag/v2.8.0) - 2025-07-07
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
        wget \
        libxml2-dev \
        jq \
+       cmake \
        git && \
     rm -rf /var/lib/apt/lists/* && \
     curl -fsSL -v -o ~/miniconda.sh -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \


### PR DESCRIPTION
Some perverse python packages require `cmake` to be built/installed, such as `sentencepiece`.

One can get around the lack of cmake in the docker image  using the `--install` command but it adds a lot of startup time because `apt update` needs to be run.