### PR TITLE
Add env var to always hide gantry logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ If you're using an image that comes with an existing system Python installation,
 - Added `--uv-torch-backend` option to `gantry run` command.
 - Added `--pre-setup` and `--post-setup` options to `gantry run` command for customizing setup steps.
 - Added `--exec-method` option to `gantry run` command for changing how gantry evaluates/executes your command.
+- Added `GANTRY_QUIET` env var, which can be used to hide the gantry logo if desired.
 
 ### Changed
 

--- a/gantry/commands/main.py
+++ b/gantry/commands/main.py
@@ -64,6 +64,7 @@ def handle_sigterm(sig, frame):
     "--quiet",
     is_flag=True,
     help="Don't display the gantry logo.",
+    envvar="GANTRY_QUIET",
 )
 @click.option(
     "--log-level",
@@ -93,8 +94,7 @@ def main(quiet: bool = False, log_level: str = "warning"):
     # Handle SIGTERM just like KeyboardInterrupt
     signal.signal(signal.SIGTERM, handle_sigterm)
 
-    hide_logo = os.environ.get("GANTRY_HIDE_LOGO", "").lower() in ("1", "true", "yes")
-    if not quiet and not hide_logo:
+    if not quiet:
         print_stderr(
             r'''
 [cyan b]                                             o=======[]   [/]

--- a/gantry/commands/main.py
+++ b/gantry/commands/main.py
@@ -93,7 +93,8 @@ def main(quiet: bool = False, log_level: str = "warning"):
     # Handle SIGTERM just like KeyboardInterrupt
     signal.signal(signal.SIGTERM, handle_sigterm)
 
-    if not quiet:
+    hide_logo = os.environ.get("GANTRY_HIDE_LOGO", "").lower() in ("1", "true", "yes")
+    if not quiet and not hide_logo:
         print_stderr(
             r'''
 [cyan b]                                             o=======[]   [/]


### PR DESCRIPTION
Reduce noise / save vertical space on the terminal window.