### PR TITLE
improve `update_workload_description()`, `--env`, and `--env-secret` options

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,6 @@ jobs:
               gantry run \
                 --show-logs \
                 --no-python \
-                --yes \
                 -- echo "Hello, World!"
 
           - name: Example - metrics 
@@ -66,7 +65,6 @@ jobs:
               gantry run \
                 --show-logs \
                 --env-secret 'BEAKER_TOKEN' \
-                --yes \
                 -- python examples/metrics/run.py
 
           - name: Example - conda from scratch
@@ -75,7 +73,6 @@ jobs:
                 --show-logs \
                 --python-manager conda \
                 --beaker-image petew/gantry-dev-tools \
-                --yes \
                 -- python --version
 
           - name: Example - conda env file
@@ -83,14 +80,12 @@ jobs:
               gantry run \
                 --show-logs \
                 --conda-file test_fixtures/conda/environment.yml \
-                --yes \
                 -- python --version
 
           - name: Example - uv from scratch
             run: |
               gantry run \
                 --show-logs \
-                --yes \
                 --beaker-image petew/gantry-dev-tools \
                 -- python --version
 
@@ -98,7 +93,6 @@ jobs:
             run: |
               gantry run \
                 --show-logs \
-                --yes \
                 --docker-image 'python:3.10' \
                 --system-python \
                 -- python --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
             run: |
               gantry run \
                 --show-logs \
-                --env-secret 'BEAKER_TOKEN=PETEW_BEAKER_TOKEN' \
+                --env-secret 'BEAKER_TOKEN' \
                 --yes \
                 -- python examples/metrics/run.py
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,8 +56,7 @@ jobs:
           - name: Example - no python
             run: |
               gantry run \
-                --workspace "$BEAKER_WORKSPACE" \
-                --timeout -1 \
+                --show-logs \
                 --no-python \
                 --yes \
                 -- echo "Hello, World!"
@@ -65,16 +64,15 @@ jobs:
           - name: Example - metrics 
             run: |
               gantry run \
-                --workspace "$BEAKER_WORKSPACE" \
-                --timeout -1 \
+                --show-logs \
+                --env-secret 'BEAKER_TOKEN=PETEW_BEAKER_TOKEN' \
                 --yes \
                 -- python examples/metrics/run.py
 
           - name: Example - conda from scratch
             run: |
               gantry run \
-                --workspace "$BEAKER_WORKSPACE" \
-                --timeout -1 \
+                --show-logs \
                 --python-manager conda \
                 --beaker-image petew/gantry-dev-tools \
                 --yes \
@@ -83,8 +81,7 @@ jobs:
           - name: Example - conda env file
             run: |
               gantry run \
-                --workspace "$BEAKER_WORKSPACE" \
-                --timeout -1 \
+                --show-logs \
                 --conda-file test_fixtures/conda/environment.yml \
                 --yes \
                 -- python --version
@@ -92,8 +89,7 @@ jobs:
           - name: Example - uv from scratch
             run: |
               gantry run \
-                --workspace "$BEAKER_WORKSPACE" \
-                --timeout -1 \
+                --show-logs \
                 --yes \
                 --beaker-image petew/gantry-dev-tools \
                 -- python --version
@@ -101,8 +97,7 @@ jobs:
           - name: Example - uv with system python
             run: |
               gantry run \
-                --workspace "$BEAKER_WORKSPACE" \
-                --timeout -1 \
+                --show-logs \
                 --yes \
                 --docker-image 'python:3.10' \
                 --system-python \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `--text` option to `gantry list` command for filtering by name or description.
+- Added `client` parameter to `api.update_workload_description()` for providing an existing Beaker client,
+  which avoids creating one each time the function is called.
+
+### Fixed
+
+- Made `api.update_workload_description()` more efficient.
 
 ## [v3.2.0](https://github.com/allenai/beaker-gantry/releases/tag/v3.2.0) - 2025-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `--text` option to `gantry list` command for filtering by name or description.
 - Added `client` parameter to `api.update_workload_description()` for providing an existing Beaker client,
   which avoids creating one each time the function is called.
+- Added support for configuring the GitHub token secret name in a `pyproject.toml` as the field `[tool.gantry.gh_token_secret]`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `client` parameter to `api.update_workload_description()` for providing an existing Beaker client,
   which avoids creating one each time the function is called.
 
+### Changed
+
+- You can now specify the `--env` option as just `--env 'NAME'` instead of `--env 'NAME=VALUE'` to take the `VALUE` from a local environment variable of that name.
+- You can now specify the `--env-secret` option as just `--env-secret 'NAME'` instead of `--env-secret 'NAME=SECRET_NAME'` to create a new secret from a local environment variable of that name.
+
 ### Fixed
 
 - Made `api.update_workload_description()` more efficient.

--- a/README.md
+++ b/README.md
@@ -134,9 +134,10 @@ pip install -e .
     Some gantry settings can also be specified in a `pyproject.toml` file under the section `[tool.gantry]`. For now those settings are:
 
     1. `workspace` - The default Beaker workspace to use.
-    2. `budget` - The default Beaker budget to use.
-    3. `log_level` - The (local) Python log level. Defaults to "warning".
-    4. `quiet` - A boolean. If true the gantry logo won't be displayed on the command line.
+    2. `gh_token_secret` - The name of the Beaker secret with your GitHub API token.
+    3. `budget` - The default Beaker budget to use.
+    4. `log_level` - The (local) Python log level. Defaults to "warning".
+    5. `quiet` - A boolean. If true the gantry logo won't be displayed on the command line.
 
     For example:
 
@@ -144,6 +145,7 @@ pip install -e .
     # pyproject.toml
     [tool.gantry]
     workspace = "ai2/my-default-workspace"
+    gh_token_secret = "GITHUB_TOKEN"
     budget = "ai2/my-teams-budget"
     log_level = "warning"
     quiet = false

--- a/examples/metrics/README.md
+++ b/examples/metrics/README.md
@@ -5,4 +5,5 @@ This example demonstrates how you can save results or metrics from an experiment
 To run this example:
 1. Copy the contents of this directory to a new GitHub repository.
 2. Commit and push all changes.
-3. Run `gantry run -- python run.py`
+3. Set the environment variable `BEAKER_TOKEN` to your Beaker API token.
+4. Run `gantry run --env-secret 'BEAKER_TOKEN' -- python run.py`

--- a/examples/metrics/run.py
+++ b/examples/metrics/run.py
@@ -2,7 +2,9 @@ import gantry
 
 
 def main():
-    gantry.api.write_metrics({"loss": 0.1, "accuracy": 0.95})
+    loss, accuracy = 0.13, 0.95
+    gantry.api.update_workload_description(f"loss={loss:.2f}, accuracy={accuracy:.2f}")
+    gantry.api.write_metrics({"loss": loss, "accuracy": accuracy})
     print("\N{check mark} Done! Metrics written to results dataset")
 
 

--- a/gantry/commands/config.py
+++ b/gantry/commands/config.py
@@ -29,9 +29,9 @@ def config():
     "-s",
     "--secret",
     type=str,
-    help="""The name of the Beaker secret to write to.""",
-    default=constants.GITHUB_TOKEN_SECRET,
-    show_default=True,
+    help=f"""The name of the Beaker secret to write to.
+    {_config.get_help_string_for_default('gh_token_secret', constants.GITHUB_TOKEN_SECRET)}""",
+    default=_config.gh_token_secret or constants.GITHUB_TOKEN_SECRET,
 )
 @click.option(
     "-y",

--- a/gantry/commands/run.py
+++ b/gantry/commands/run.py
@@ -219,9 +219,9 @@ from .main import CLICK_COMMAND_DEFAULTS, config, main, new_optgroup
 @optgroup.option(
     "--gh-token-secret",
     type=str,
-    help="""The name of the Beaker secret that contains your GitHub token.""",
-    default=constants.GITHUB_TOKEN_SECRET,
-    show_default=True,
+    help=f"""The name of the Beaker secret that contains your GitHub token.
+    {config.get_help_string_for_default('gh_token_secret', constants.GITHUB_TOKEN_SECRET)}""",
+    default=config.gh_token_secret or constants.GITHUB_TOKEN_SECRET,
 )
 @new_optgroup("Outputs")
 @optgroup.option(

--- a/gantry/commands/run.py
+++ b/gantry/commands/run.py
@@ -183,7 +183,9 @@ from .main import CLICK_COMMAND_DEFAULTS, config, main, new_optgroup
     "--env",
     "env_vars",
     type=str,
-    help="""Environment variables to add the Beaker experiment. Should be in the form '{NAME}={VALUE}'.""",
+    help="""Environment variables to add the Beaker experiment.
+    Should be in the form '{NAME}={VALUE}', or just '{NAME}' to take the value from a local environment
+    variable of that name.""",
     multiple=True,
 )
 @optgroup.option(
@@ -191,8 +193,9 @@ from .main import CLICK_COMMAND_DEFAULTS, config, main, new_optgroup
     "--secret-env",
     "env_secrets",
     type=str,
-    help="""Environment variables to add the Beaker experiment from Beaker secrets.
-    Should be in the form '{NAME}={SECRET_NAME}'.""",
+    help="""Environment variables to add to the Beaker experiment from Beaker secrets.
+    Should be in the form '{NAME}={SECRET_NAME}', or just '{NAME}' to take the value from a local
+    environment variable of that name and create a new secret.""",
     multiple=True,
 )
 @optgroup.option(

--- a/gantry/config.py
+++ b/gantry/config.py
@@ -11,6 +11,7 @@ from .exceptions import ConfigurationError
 @dataclass
 class GantryConfig:
     workspace: Optional[str] = None
+    gh_token_secret: Optional[str] = None
     budget: Optional[str] = None
     log_level: Optional[Literal["debug", "info", "warning", "error"]] = None
     quiet: Optional[bool] = None
@@ -46,7 +47,9 @@ class GantryConfig:
             return f"'{value}'"
 
     def get_help_string_for_default(
-        self, field: Literal["workspace", "budget", "log_level", "quiet"], default: Any = None
+        self,
+        field: Literal["workspace", "gh_token_secret", "budget", "log_level", "quiet"],
+        default: Any = None,
     ) -> str:
         value = getattr(self, field)
         if value is None and default is None:

--- a/gantry/util.py
+++ b/gantry/util.py
@@ -504,6 +504,7 @@ def init_client(
     yes: bool = False,
     ensure_workspace: bool = True,
     beaker_token: Optional[str] = None,
+    check_for_upgrades: bool = True,
 ) -> Beaker:
     Beaker.MAX_RETRIES = 10_000  # effectively retry forever
     Beaker.BACKOFF_MAX = 32
@@ -513,7 +514,7 @@ def init_client(
         kwargs["default_workspace"] = workspace
     if beaker_token is not None:
         kwargs["user_token"] = beaker_token
-    beaker = Beaker.from_env(**kwargs)  # type: ignore[arg-type]
+    beaker = Beaker.from_env(check_for_upgrades=check_for_upgrades, **kwargs)  # type: ignore[arg-type]
 
     if ensure_workspace and workspace is None:
         try:

--- a/gantry/util.py
+++ b/gantry/util.py
@@ -1,4 +1,5 @@
 import binascii
+import hashlib
 import json
 import platform
 import tempfile
@@ -28,11 +29,7 @@ from beaker import (
     BeakerWorkloadType,
     BeakerWorkspace,
 )
-from beaker.exceptions import (
-    BeakerDatasetConflict,
-    BeakerSecretNotFound,
-    BeakerWorkspaceNotSet,
-)
+from beaker.exceptions import BeakerDatasetConflict, BeakerWorkspaceNotSet
 from rich import prompt
 from rich.console import Console
 
@@ -337,7 +334,6 @@ def filter_clusters_by_gpu_type(
 
 
 def ensure_entrypoint_dataset(beaker: Beaker) -> BeakerDataset:
-    import hashlib
     from importlib.resources import read_binary
 
     import gantry
@@ -414,21 +410,6 @@ def ensure_entrypoint_dataset(beaker: Beaker) -> BeakerDataset:
             )
 
     return gantry_entrypoint_dataset
-
-
-def ensure_github_token_secret(
-    beaker: Beaker, secret_name: str = constants.GITHUB_TOKEN_SECRET
-) -> str:
-    try:
-        beaker.secret.get(secret_name)
-    except BeakerSecretNotFound:
-        raise GitHubTokenSecretNotFound(
-            f"GitHub token secret '{secret_name}' not found in Beaker workspace!\n"
-            f"You can create a suitable GitHub token by going to https://github.com/settings/tokens/new "
-            f"and generating a token with '\N{ballot box with check} repo' scope.\n"
-            f"Then upload your token as a Beaker secret using the Beaker CLI or Python client."
-        )
-    return secret_name
 
 
 def format_timedelta(td: "timedelta") -> str:


### PR DESCRIPTION
- Added `client` parameter to `api.update_workload_description()` for providing an existing Beaker client,
  which avoids creating one each time the function is called.
- Don't check for upgrades when creating a client in `api.update_workload_description()`.
- Added support for configuring the GitHub token secret name in a `pyproject.toml` as the field `[tool.gantry.gh_token_secret]`.
- You can now specify the `--env` option as just `--env 'NAME'` instead of `--env 'NAME=VALUE'` to take the `VALUE` from a local environment variable of that name.
- You can now specify the `--env-secret` option as just `--env-secret 'NAME'` instead of `--env-secret 'NAME=SECRET_NAME'` to create a new secret from a local environment variable of that name.