### PR TITLE
Fix "waiting on" to "waiting for"

### DIFF
--- a/gantry/launch.py
+++ b/gantry/launch.py
@@ -718,7 +718,7 @@ def follow_workload(
 
             # Wait for job to be created...
             with ExitStack() as stack:
-                msg = "[i]waiting on job...[/]"
+                msg = "[i]waiting for job...[/]"
                 status: Status | None = None
                 if not os.environ.get("GANTRY_GITHUB_TESTING"):
                     status = stack.enter_context(console.status(msg, spinner="point", speed=0.8))


### PR DESCRIPTION
## Summary
- Fixed grammar: "waiting on job..." → "waiting for job..." in the job follow status message.

## Test plan
- [ ] Verify the status message displays correctly when following a workload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)