### PR TITLE
Add min runtime support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `--min-runtime` option to `gantry run` for specifying a minimum guaranteed runtime before a job can be preempted (e.g. `--min-runtime 1h`).
+- Added `--no-auto-resume` option to `gantry run` for disabling automatic job resumption after preemption.
+
+### Changed
+
+- Bumped minimum `beaker-py` version to 2.6.0.
+- When no cluster is specified, gantry no longer explicitly sets `preemptible=True`. The server defaults (`min_runtime=0`, `auto_resume=true`) now apply, which is equivalent behavior.
+
+### Deprecated
+
+- `--preemptible/--not-preemptible` is deprecated in favor of `--min-runtime` and `--no-auto-resume`. The old flags still work but emit a deprecation warning.
+
 ## [v3.6.0](https://github.com/allenai/beaker-gantry/releases/tag/v3.6.0) - 2026-03-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -347,6 +347,26 @@ Then change your `gantry run` command like this:
 ```
 </details>
 
+### How can I control job preemption behavior?
+<details>
+<summary>Click to expand 💬</summary>
+
+Use `--min-runtime` to specify the minimum time your job needs to make and durably save progress before it can be preempted.
+This should cover your initialization, a full training step or checkpoint cycle, and saving the checkpoint.
+For example:
+
+```bash
+gantry run --show-logs --min-runtime='1h' -- python train.py
+```
+
+By default, jobs can be preempted at any time (`min_runtime=0`) and will automatically resume after preemption.
+To disable automatic resumption, add `--no-auto-resume`:
+
+```bash
+gantry run --show-logs --min-runtime='30m' --no-auto-resume -- python train.py
+```
+</details>
+
 ### How can I customize the Python setup steps?
 <details>
 <summary>Click to expand 💬</summary>
@@ -445,7 +465,6 @@ jobs:
             --ref ${{ env.COMMIT_SHA }} \
             --branch ${{ env.BRANCH_NAME }} \
             --priority normal \
-            --preemptible \
             --gpus 1 \
             --gpu-type h100 \
             --gpu-type a100 \

--- a/gantry/beaker_utils.py
+++ b/gantry/beaker_utils.py
@@ -8,7 +8,7 @@ import tempfile
 import time
 from collections import defaultdict
 from contextlib import ExitStack
-from datetime import datetime
+from datetime import datetime, timedelta
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Iterable, Literal, Sequence
@@ -544,7 +544,7 @@ def display_results(
     callbacks: Sequence[Callback] | None = None,
 ):
     status = job.status.status
-    runtime = job.status.exited - job.status.started  # type: ignore
+    runtime: timedelta = job.status.exited - job.status.started  # type: ignore
     results_ds = beaker.dataset.get(job.assignment_details.result_dataset_id)
 
     if status == BeakerWorkloadStatus.succeeded:
@@ -628,6 +628,8 @@ def build_experiment_spec(
     uploads: list[tuple[str, str]] | None = None,
     hostnames: list[str] | None = None,
     preemptible: bool | None = None,
+    min_runtime: str | None = None,
+    auto_resume: bool | None = None,
     retries: int | None = None,
     results: str = constants.RESULTS_DIR,
     runtime_dir: str = constants.RUNTIME_DIR,
@@ -654,6 +656,8 @@ def build_experiment_spec(
             resources=task_resources,
             priority=priority,
             preemptible=preemptible,
+            min_runtime=min_runtime,
+            auto_resume=auto_resume,
             replicas=replicas,
             leader_selection=leader_selection,
             host_networking=host_networking,

--- a/gantry/commands/run.py
+++ b/gantry/commands/run.py
@@ -152,8 +152,7 @@ log = logging.getLogger(__name__)
     default=None,
     help="""The name of a cluster to use or a glob pattern, e.g. --cluster='ai2/*-cirrascale'.
     Multiple allowed.
-    If you don't specify a cluster or the priority, the priority will default to 'preemptible' and
-    the job will be able to run on any on-premise cluster.""",
+    If you don't specify a cluster, the job will be able to run on any on-premise cluster.""",
     show_default=True,
 )
 @optgroup.option(
@@ -360,11 +359,27 @@ log = logging.getLogger(__name__)
     show_default=True,
 )
 @optgroup.option(
+    "--min-runtime",
+    type=str,
+    help="""Minimum guaranteed runtime before a job can be preempted, e.g. '1h', '30m'.
+    A value of '0' (the server default) means the job can be preempted at any time.""",
+    default=None,
+)
+@optgroup.option(
+    "--no-auto-resume",
+    "auto_resume",
+    is_flag=True,
+    flag_value=False,
+    help="""Disable automatic job resumption after preemption.
+    If not specified, the server default (auto-resume enabled) is used.""",
+    default=None,
+)
+@optgroup.option(
     "--preemptible/--not-preemptible",
     is_flag=True,
-    help="""Mark the job as preemptible or not. If you don't specify at least one cluster then
-    jobs will default to preemptible.""",
+    help="""[Deprecated] Use --min-runtime and --no-auto-resume instead.""",
     default=None,
+    hidden=True,
 )
 @optgroup.option(
     "--retries", type=int, help="""Specify the number of automatic retries for the experiment."""
@@ -602,6 +617,19 @@ def run(
             f"{', '.join([repr(s) for s in invalid_args])}.\n"
             "Hint: you might be trying to pass a value to a FLAG option.\n"
             "Try 'gantry run --help' for help."
+        )
+
+    # Validate preemptible vs min_runtime/auto_resume.
+    if kwargs.get("preemptible") is not None:
+        if kwargs.get("min_runtime") is not None or kwargs.get("auto_resume") is not None:
+            raise ConfigurationError(
+                f"{utils.fmt_opt('--preemptible')} cannot be used together with "
+                f"{utils.fmt_opt('--min-runtime')} or {utils.fmt_opt('--no-auto-resume')}. "
+                f"Please use {utils.fmt_opt('--min-runtime')} and/or {utils.fmt_opt('--no-auto-resume')} instead."
+            )
+        utils.print_stderr(
+            "[yellow]Warning: --preemptible/--not-preemptible is deprecated. "
+            "Use --min-runtime and/or --no-auto-resume instead.[/]"
         )
 
     # Parse timeouts.

--- a/gantry/commands/run.py
+++ b/gantry/commands/run.py
@@ -152,7 +152,7 @@ log = logging.getLogger(__name__)
     default=None,
     help="""The name of a cluster to use or a glob pattern, e.g. --cluster='ai2/*-cirrascale'.
     Multiple allowed.
-    If you don't specify a cluster, the job will be able to run on any on-premise cluster.""",
+    If you don't specify a cluster, Beaker will attempt to schedule on any available on-premise cluster.""",
     show_default=True,
 )
 @optgroup.option(
@@ -377,9 +377,9 @@ log = logging.getLogger(__name__)
 @optgroup.option(
     "--preemptible/--not-preemptible",
     is_flag=True,
-    help="""[Deprecated] Use --min-runtime and --no-auto-resume instead.""",
+    help="""Use --min-runtime and --no-auto-resume instead.""",
     default=None,
-    hidden=True,
+    deprecated="Use --min-runtime and/or --no-auto-resume instead.",
 )
 @optgroup.option(
     "--retries", type=int, help="""Specify the number of automatic retries for the experiment."""
@@ -627,10 +627,6 @@ def run(
                 f"{utils.fmt_opt('--min-runtime')} or {utils.fmt_opt('--no-auto-resume')}. "
                 f"Please use {utils.fmt_opt('--min-runtime')} and/or {utils.fmt_opt('--no-auto-resume')} instead."
             )
-        utils.print_stderr(
-            "[yellow]Warning: --preemptible/--not-preemptible is deprecated. "
-            "Use --min-runtime and/or --no-auto-resume instead.[/]"
-        )
 
     # Parse timeouts.
     # NOTE: `timeout_str` has to be handled specially because of the '-1' value.

--- a/gantry/launch.py
+++ b/gantry/launch.py
@@ -93,6 +93,8 @@ def launch_experiment(
     synchronized_start_timeout: str | None = None,
     budget: str | None = None,
     preemptible: bool | None = None,
+    min_runtime: str | None = None,
+    auto_resume: bool | None = None,
     retries: int | None = None,
     results: str = constants.RESULTS_DIR,
     runtime_dir: str = constants.RUNTIME_DIR,
@@ -396,10 +398,6 @@ def launch_experiment(
             else:
                 clusters = [f"{cl.organization_name}/{cl.name}" for cl in all_clusters]
 
-        # Default to preemptible when no cluster has been specified.
-        if not clusters and preemptible is None:
-            preemptible = True
-
         # Get / set the GitHub token secret.
         gh_token_secret_to_use: str | None = None
         if not git_repo.is_public and "GITHUB_TOKEN" not in secret_names:
@@ -526,6 +524,8 @@ def launch_experiment(
             uploads=uploads_to_use,
             hostnames=None if hostnames is None else list(hostnames),
             preemptible=preemptible,
+            min_runtime=min_runtime,
+            auto_resume=auto_resume,
             retries=retries,
             results=results,
             runtime_dir=runtime_dir,

--- a/gantry/recipe.py
+++ b/gantry/recipe.py
@@ -74,7 +74,9 @@ class Recipe:
     task_name: str = "main"
     priority: str | None = None
     task_timeout: str | None = None
-    preemptible: bool | None = None
+    preemptible: bool | None = dataclasses.field(default=None, repr=False)  # deprecated
+    min_runtime: str | None = None
+    auto_resume: bool | None = None
     retries: int | None = None
 
     # Multi-node config.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "beaker-py>=2.5.1,<3.0",
+    "beaker-py>=2.6.0,<3.0",
     "GitPython>=3.0,<4.0",
     "rich",
     "click",

--- a/tests/commands/run_test.py
+++ b/tests/commands/run_test.py
@@ -48,8 +48,8 @@ def test_dry_run(workspace_name: str, run_name: str, tmp_path: Path):
 
     # Make sure spec is valid.
     spec = BeakerExperimentSpec.from_file(spec_path)
-    # Should be preemptible since we didn't specify a cluster.
-    assert spec.tasks[0].context.preemptible is True
+    # No preemption settings specified, server defaults apply.
+    assert spec.tasks[0].context.preemptible is None
 
 
 def test_dry_run_not_preemptible(workspace_name: str, run_name: str, tmp_path: Path):
@@ -65,10 +65,10 @@ def test_dry_run_not_preemptible(workspace_name: str, run_name: str, tmp_path: P
         text=True,
     )
     assert result.returncode == 0
+    assert "deprecated" in result.stderr.lower()
 
     # Make sure spec is valid.
     spec = BeakerExperimentSpec.from_file(spec_path)
-    # Should be preemptible since we didn't specify a cluster.
     assert spec.tasks[0].context.preemptible is False
 
 
@@ -130,6 +130,60 @@ def test_dry_run_with_weka_tag(
     assert spec.tasks[0].constraints.cluster is not None
     constrained_clusters = set(spec.tasks[0].constraints.cluster)
     assert constrained_clusters
+
+
+def test_dry_run_min_runtime(workspace_name: str, run_name: str, tmp_path: Path):
+    spec_path = tmp_path / "spec.yaml"
+    result = subprocess.run(
+        _build_run_cmd(
+            workspace_name=workspace_name,
+            run_name=run_name,
+            spec_path=spec_path,
+            options=["--min-runtime", "1h"],
+        ),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+    spec = BeakerExperimentSpec.from_file(spec_path)
+    assert spec.tasks[0].context.min_runtime == to_nanoseconds("1h")
+
+
+def test_dry_run_no_auto_resume(workspace_name: str, run_name: str, tmp_path: Path):
+    spec_path = tmp_path / "spec.yaml"
+    result = subprocess.run(
+        _build_run_cmd(
+            workspace_name=workspace_name,
+            run_name=run_name,
+            spec_path=spec_path,
+            options=["--no-auto-resume"],
+        ),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+    spec = BeakerExperimentSpec.from_file(spec_path)
+    assert spec.tasks[0].context.auto_resume is False
+
+
+def test_dry_run_preemptible_with_min_runtime_error(
+    workspace_name: str, run_name: str, tmp_path: Path
+):
+    spec_path = tmp_path / "spec.yaml"
+    result = subprocess.run(
+        _build_run_cmd(
+            workspace_name=workspace_name,
+            run_name=run_name,
+            spec_path=spec_path,
+            options=["--preemptible", "--min-runtime", "1h"],
+        ),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "cannot be used together" in result.stderr.lower()
 
 
 def test_dry_run_with_budget(workspace_name: str, run_name: str, tmp_path: Path):


### PR DESCRIPTION
This adds support to Gantry for specifying a minimum runtime and for disabling auto-resume (which is enabled by default). I added unit tests and tested manually by creating several new jobs.