### PR TITLE
Update budget to ai2/infra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,5 +131,5 @@ reportWildcardImportFromLibrary = false
 
 [tool.gantry]
 workspace = "ai2/gantry-beaker-py"
-budget = "ai2/compute"
+budget = "ai2/infra"
 log_level = "warning"

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -5,4 +5,4 @@ def test_load_config():
     config = GantryConfig.load()  # loads from pyproject.toml
     assert isinstance(config, GantryConfig)
     assert config.workspace == "ai2/gantry-beaker-py"
-    assert config.budget == "ai2/compute"
+    assert config.budget == "ai2/infra"


### PR DESCRIPTION
`ai2/compute` is deprecated in favor or `ai2/infra`.